### PR TITLE
Minor modification to Io's Lightning Skill ID Translations

### DIFF
--- a/act_ws_texts.js
+++ b/act_ws_texts.js
@@ -423,7 +423,10 @@ const i18nCfg = {
                         "3000": "Fire",
                         "4000": "Flowery Seven",
                         "7200": "Gravity Well",
-                        "8202": "Lightning"
+                        "8200": "Lightning",
+                        "8201": "Lightning",
+                        "8202": "Lightning",
+                        "8203": "Lightning"
                     },
                 },
                 actors: {

--- a/act_ws_texts.js
+++ b/act_ws_texts.js
@@ -423,10 +423,10 @@ const i18nCfg = {
                         "3000": "Fire",
                         "4000": "Flowery Seven",
                         "7200": "Gravity Well",
-                        "8200": "Lightning",
-                        "8201": "Lightning",
-                        "8202": "Lightning",
-                        "8203": "Lightning"
+                        "8200": "Lightning w/ 0 orbs",
+                        "8201": "Lightning w/ 1 orb",
+                        "8202": "Lightning w/ 2 orbs",
+                        "8203": "Lightning w/ 3 orbs"
                     },
                 },
                 actors: {


### PR DESCRIPTION
Sorry for the quick PR. This is to help differentiate between different Lightning skill casts. I did not know there were multiple skill ID's or what caused the difference before.