### PR TITLE
add current directory to sys path

### DIFF
--- a/act_ws.py
+++ b/act_ws.py
@@ -16,6 +16,9 @@ from select import select
 from http.server import BaseHTTPRequestHandler  # pylint: disable=import-error
 from io import StringIO, BytesIO
 
+import sys
+sys.path.append(os.getcwd())
+
 unicode = str  # pylint: disable=redefined-builtin
 
 __all__ = [


### PR DESCRIPTION
win10，python311 embed版本。无论是python311放到系统环境变量首位再运行uac_start.cmd，还是直接python311绝对路径+act_ws.py运行，都会报ModuleNotFoundError，当前工作路径加到sys.path后可以解决
```powershell
PS D:\git-clone\GBFR-ACT> D:\git-clone\Uma-python\python-3.11.4-embed-amd64\python.exe D:\git-clone\GBFR-ACT\act_ws.py
Traceback (most recent call last):
  File "D:\git-clone\GBFR-ACT\act_ws.py", line 711, in <module>
    from injector import Act, Process, run_admin, enable_privilege
ModuleNotFoundError: No module named 'injector'
```