### PR TITLE
Update act_ws.html

### DIFF
--- a/act_ws.html
+++ b/act_ws.html
@@ -527,9 +527,9 @@
                         if (cutoff_idx >= 0) dataset.data = dataset.data.slice(cutoff_idx);
                     }
                 }
-                for (const {display_name, damage, dps} of record.actors) {
+                for (const {display_name, damage, dps_in_minute} of record.actors) {
                     const dps_dataset = this.dps_chart_data.datasets.find(ds => ds.label === display_name);
-                    if (dps_dataset) dps_dataset.data.push({x: time_sec, y: dps});
+                    if (dps_dataset) dps_dataset.data.push({x: time_sec, y: dps_in_minute});
                     const dmg_dataset = this.dmg_chart_data.datasets.find(ds => ds.label === display_name);
                     if (dmg_dataset) dmg_dataset.data.push({x: time_sec, y: damage});
                 }


### PR DESCRIPTION
Updated act_ws.html to correctly use dps_in_minute for dps(min) charts, fixing the previous incorrect use of dps.

更新了 act_ws.html 文件，現在正確使用 dps_in_minute 取代之前錯誤使用的 dps，以修正 DPS(分) 圖表的顯示問題。

![dps分圖表對比](https://github.com/nyaoouo/GBFR-ACT/assets/8299577/b32ac345-949e-4a11-965c-be0cca9b4445)
![總傷參考](https://github.com/nyaoouo/GBFR-ACT/assets/8299577/98b56a25-a596-4215-a55e-09d597ba1273)
