### PR TITLE
Enhance damage insights and filter minor outliers in act_ws.html

### DIFF
--- a/act_ws.html
+++ b/act_ws.html
@@ -239,7 +239,7 @@
                             </el-table-column>
                             <el-table-column :label="$t('ui.damage_avg')">
                                 <template #default="scope">
-                                    <span v-if="scope.row.hit > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}} ({{(scope.row.damage / scope.row.hit /scope.row.max*100).toFixed(1)}}%)</span>
+                                    <span v-if="scope.row.hit > 0 && scope.row.max > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}} ({{(scope.row.damage / scope.row.hit / scope.row.max * 100).toFixed(1)}}%)</span>
                                 </template>
                             </el-table-column>
                         </el-table>

--- a/act_ws.html
+++ b/act_ws.html
@@ -239,7 +239,7 @@
                             </el-table-column>
                             <el-table-column :label="$t('ui.damage_avg')">
                                 <template #default="scope">
-                                    <span v-if="scope.row.hit > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}}</span>
+                                    <span v-if="scope.row.hit > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}} ({{(scope.row.damage / scope.row.hit /scope.row.max*100).toFixed(1)}}%)</span>
                                 </template>
                             </el-table-column>
                         </el-table>
@@ -863,6 +863,7 @@
                     const [source_type, source_idx, source_id, source_party_idx, ..._] = source;
                     const [target_type, target_idx, target_id, target_party_idx, ...__] = target;
                     if (target_id === 0x22a350f) return; // HARDCODE: 对欧根附加炸弹造成的伤害不进行记录
+                    if (damage < 1000) return; // HARDCODE: filter outliner damage (<1000)
                     // TODO: 自伤类技能的过滤
                     const current_record = get_latest_record();
                     current_record.last_record_at = time_ms;

--- a/act_ws.html
+++ b/act_ws.html
@@ -950,6 +950,8 @@
                     ['damage', 'damage_in_minute', 'dps', 'dps_in_minute', 'detail'].map(k => {
                         if (!(k in cfg_val.main_tbl_cols_display)) cfg_val.main_tbl_cols_display[k] = true;
                     })
+                    setdefault('bool_damage_filter', false);
+                    setdefault('number_damage_filter', 0);
                     cfg.value = cfg_val;
                 }
 

--- a/act_ws.html
+++ b/act_ws.html
@@ -297,6 +297,10 @@
                                                     :active-text="$t(`ui.${k}`)"
                                             ></el-switch>
                                         </el-form-item>
+                                        <el-form-item :label="$t('ui.damage_filter')">
+                                            <el-switch v-model="cfg.bool_damage_filter" :active-text="$t('ui.damage_filter_desc')"></el-switch>
+                                            <el-input-number v-model="cfg.number_damage_filter" :min="0" :step="100" :disabled="!cfg.bool_damage_filter"></el-input-number>
+                                        </el-form-item>
                                     </el-form>
 
                                     <el-button class="w-100" @click="export_log(item)">
@@ -863,7 +867,7 @@
                     const [source_type, source_idx, source_id, source_party_idx, ..._] = source;
                     const [target_type, target_idx, target_id, target_party_idx, ...__] = target;
                     if (target_id === 0x22a350f) return; // HARDCODE: 对欧根附加炸弹造成的伤害不进行记录
-                    if (damage < 1000) return; // HARDCODE: filter outliner damage (<1000)
+                    if (cfg.value.bool_damage_filter && damage <= cfg.value.number_damage_filter) return; // 小伤害过滤
                     // TODO: 自伤类技能的过滤
                     const current_record = get_latest_record();
                     current_record.last_record_at = time_ms;

--- a/act_ws_texts.js
+++ b/act_ws_texts.js
@@ -44,6 +44,8 @@ const i18nCfg = {
                 tbl_main_col: "主要表格栏",
                 keep_record: "保留最后一次记录",
                 export_log: "下载当前战斗记录",
+                damage_filter: "小伤害过滤",
+                damage_filter_desc: "过滤(包含)",
             },
             game: {
                 actions: {
@@ -1093,6 +1095,8 @@ const i18nCfg = {
                 language: "語言",
                 chart_main: "主要圖表",
                 keep_record: "保留最後一次記錄",
+                damage_filter: "小傷害過濾",
+                damage_filter_desc: "過濾(包含)",
             },
             game: {
                 actions: {
@@ -2169,6 +2173,8 @@ const i18nCfg = {
                 language: "language",
                 chart_main: "main chart",
                 keep_record: "keep the last record",
+                damage_filter: "damage filter",
+                damage_filter_desc: "filter(inclusive)",
             },
             game: {
                 actions: {


### PR DESCRIPTION
- Updated act_ws.html to display the average damage as a percentage of the maximum damage (assumed to equal the damage cap), offering deeper insights into achieving the potential damage cap.
- Added a hard-coded filter in act_ws.html to ignore damage records less than 1000 (a magic number), focusing on reasonable damage instances and filtering out minor outliers to calculate a more accurate average.
- 更新了 act_ws.html，使其顯示平均傷害作為相對於最大傷害（假設等同於傷害上限）的百分比，提供對於實現潛在傷害上限的更深入見解。
- 增加了一個硬編碼過濾器來忽略小於1000的傷害記錄（一個魔法數字），專注於合理的傷害實例並過濾掉輕微的異常值，以計算更準確的平均值。

這是關於傷害上限的初步嘗試，我認為效果相當好，具體能幫助我決策替換追擊收益。我最初是將0傷害過濾，發現包含水晶等仍有許多微小傷害，只好先使用魔法數字。功能性方面，追擊、奧義明顯錯誤，且OVERDRIVE沒考慮。拋磚引玉，如果有方向我再優化。
![效果1](https://github.com/nyaoouo/GBFR-ACT/assets/8299577/79f3c792-2236-4972-9c5e-967e6423c53b)
![效果2](https://github.com/nyaoouo/GBFR-ACT/assets/8299577/c71ab195-cea5-41b2-92e8-c6ca06329be4)
![基準](https://github.com/nyaoouo/GBFR-ACT/assets/8299577/a85277c8-cef6-45f2-b464-9d7c582e67c4)

