### PR TITLE
fix: cannot export log due to party structure change

### DIFF
--- a/act_ws.html
+++ b/act_ws.html
@@ -821,8 +821,8 @@
                             const action_id = evt_action_id(data);
                             const date = new Date(time_ms);
                             return `${date.getFullYear()}/${date.getMonth()}/${date.getDay()} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}|damage|` +
-                                    `${source_type};${source_idx};${numberToHexStringWithZFill(source_id, 8)};${source_party_idx};${actor_name(source_id)}|` +
-                                    `${target_type};${target_idx};${numberToHexStringWithZFill(target_id, 8)};${target_party_idx};${actor_name(target_id)}|` +
+                                    `${source_type};${source_idx};${numberToHexStringWithZFill(source_id, 8)};${source_party_idx};${actor_name(source_type)}|` +
+                                    `${target_type};${target_idx};${numberToHexStringWithZFill(target_id, 8)};${target_party_idx};${actor_name(target_type)}|` +
                                     `${action_id}|${action_name(source_id, action_id)}|${damage}|${flags}\n`;
                     }
                     return '';


### PR DESCRIPTION
Click "Export log" button yields the following error:

```
vue.global.js:1830 Uncaught TypeError: name_key.toUpperCase is not a function
    at actor_name (act_ws.html:515:33)
    at act_ws.html:824:133
    at Array.map (<anonymous>)
    at Proxy.export_log (act_ws.html:815:63)
    at Proxy.export_log (act_ws.html:870:55)
    at onClick (eval at compileToFunction (vue.global.js:16501:20), <anonymous>:470:53)
    at callWithErrorHandling (vue.global.js:1768:21)
    at callWithAsyncErrorHandling (vue.global.js:1775:19)
    at emit (vue.global.js:2286:7)
    at vue.global.js:9263:47
```

This is due to the recent change of party member info. So I drafted this quick fix for this issue.